### PR TITLE
Fix broken badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Alpine Magic Helpers
 A set of magic helpers to use with AlpineJS
 
-![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/kevinbatdorf/alpine-magic-helpers?label=version&style=flat-square)
+![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/alpine-collective/alpine-magic-helpers?label=version&style=flat-square)
 
 ## About
 


### PR DESCRIPTION
imgshield doesn't work when using the old url.