### PR TITLE
Only append the ellipsis if the text was truncated

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1707,6 +1707,8 @@
 
     var AlpineTruncateMagicMethod = {
       start: function start() {
+        var _this = this;
+
         checkForAlpine();
         Alpine.addMagicProperty('truncate', function () {
           return function () {
@@ -1714,43 +1716,41 @@
               parameters[_key] = arguments[_key];
             }
 
-            if (typeof parameters[0] !== 'string') return parameters[0];
-            var truncatedText;
-            var ellipsis = '…'; // If the second parameter isn't truthy, return the full string
+            if (typeof parameters[0] !== 'string') return parameters[0]; // If the second parameter isn't truthy, return the full string
 
             if (!parameters[1]) return parameters[0]; // if only a number or string is passed in, keep it simple
 
             if (typeof parameters[1] !== 'object') {
-              if (typeof parameters[2] !== 'undefined') {
-                ellipsis = parameters[2];
-              }
-
-              truncatedText = parameters[0].slice(0, parameters[1]);
-            } else {
-              // Customize the …
-              if (Object.prototype.hasOwnProperty.call(parameters[1], 'ellipsis')) {
-                ellipsis = parameters[1].ellipsis;
-              } // If words or characters is set, also check that they are truthy.
-              // Setting to 0, for example, should show all
+              return _this.appendEllipsis(parameters[0].slice(0, parameters[1]), parameters);
+            } // If words or characters is set, also check that they are truthy. Setting to 0, for example, shoudld show all
 
 
-              if (Object.prototype.hasOwnProperty.call(parameters[1], 'words') && parameters[1].words) {
-                truncatedText = parameters[0].split(' ').splice(0, parameters[1].words).join(' ');
-              } else if (Object.prototype.hasOwnProperty.call(parameters[1], 'characters') && parameters[1].characters) {
-                truncatedText = parameters[0].slice(0, parameters[1].characters);
-              } else {
-                truncatedText = parameters[0];
-              }
-            } // Only append the ellipsis if the text was truncated
-
-
-            if (truncatedText.length < parameters[0].length) {
-              return truncatedText + ellipsis;
-            } else {
-              return truncatedText;
+            if (Object.prototype.hasOwnProperty.call(parameters[1], 'words') && parameters[1].words) {
+              return _this.appendEllipsis(parameters[0].split(' ').splice(0, parameters[1].words).join(' '), parameters);
             }
+
+            if (Object.prototype.hasOwnProperty.call(parameters[1], 'characters') && parameters[1].characters) {
+              return _this.appendEllipsis(parameters[0].slice(0, parameters[1].characters), parameters);
+            }
+
+            return parameters[0];
           };
         });
+      },
+      appendEllipsis: function appendEllipsis(string, parameters) {
+        if (parameters[0].length <= string.length) return string;
+        var ellipsis = '…'; // 3rd parameter is an optional '…' override (soon to be deprecated)
+
+        if (typeof parameters[2] !== 'undefined') {
+          ellipsis = parameters[2];
+        } // If the second parameter is an object
+
+
+        if (Object.prototype.hasOwnProperty.call(parameters[1], 'ellipsis')) {
+          ellipsis = parameters[1].ellipsis;
+        }
+
+        return string + ellipsis;
       }
     };
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1715,33 +1715,41 @@
             }
 
             if (typeof parameters[0] !== 'string') return parameters[0];
+            var originalText = parameters[0];
+            var truncatedText;
             var ellipsis = '…'; // If the second parameter isn't truthy, return the full string
 
-            if (!parameters[1]) return parameters[0]; // if only a number or string is passed in, keep it simple
+            if (!parameters[1]) return originalText; // if only a number or string is passed in, keep it simple
 
             if (typeof parameters[1] !== 'object') {
               if (typeof parameters[2] !== 'undefined') {
                 ellipsis = parameters[2];
               }
 
-              return parameters[0].slice(0, parameters[1]) + ellipsis;
-            } // Customize the …
+              truncatedText = originalText.slice(0, parameters[1]);
+            } else {
+              // Customize the …
+              if (Object.prototype.hasOwnProperty.call(parameters[1], 'ellipsis')) {
+                ellipsis = parameters[1].ellipsis;
+              } // If words or characters is set, also check that they are truthy.
+              // Setting to 0, for example, should show all
 
 
-            if (Object.prototype.hasOwnProperty.call(parameters[1], 'ellipsis')) {
-              ellipsis = parameters[1].ellipsis;
-            } // If words or characters is set, also check that they are truthy. Setting to 0, for example, shoudld show all
+              if (Object.prototype.hasOwnProperty.call(parameters[1], 'words') && parameters[1].words) {
+                truncatedText = originalText.split(' ').splice(0, parameters[1].words).join(' ');
+              } else if (Object.prototype.hasOwnProperty.call(parameters[1], 'characters') && parameters[1].characters) {
+                truncatedText = originalText.slice(0, parameters[1].characters);
+              } else {
+                truncatedText = originalText;
+              }
+            } // Only append the ellipsis if the text was truncated
 
 
-            if (Object.prototype.hasOwnProperty.call(parameters[1], 'words') && parameters[1].words) {
-              return parameters[0].split(' ').splice(0, parameters[1].words).join(' ') + ellipsis;
+            if (truncatedText.length < originalText.length) {
+              return truncatedText + ellipsis;
+            } else {
+              return truncatedText;
             }
-
-            if (Object.prototype.hasOwnProperty.call(parameters[1], 'characters') && parameters[1].characters) {
-              return parameters[0].slice(0, parameters[1].characters) + ellipsis;
-            }
-
-            return parameters[0];
           };
         });
       }

--- a/dist/index.js
+++ b/dist/index.js
@@ -1715,18 +1715,17 @@
             }
 
             if (typeof parameters[0] !== 'string') return parameters[0];
-            var originalText = parameters[0];
             var truncatedText;
             var ellipsis = '…'; // If the second parameter isn't truthy, return the full string
 
-            if (!parameters[1]) return originalText; // if only a number or string is passed in, keep it simple
+            if (!parameters[1]) return parameters[0]; // if only a number or string is passed in, keep it simple
 
             if (typeof parameters[1] !== 'object') {
               if (typeof parameters[2] !== 'undefined') {
                 ellipsis = parameters[2];
               }
 
-              truncatedText = originalText.slice(0, parameters[1]);
+              truncatedText = parameters[0].slice(0, parameters[1]);
             } else {
               // Customize the …
               if (Object.prototype.hasOwnProperty.call(parameters[1], 'ellipsis')) {
@@ -1736,16 +1735,16 @@
 
 
               if (Object.prototype.hasOwnProperty.call(parameters[1], 'words') && parameters[1].words) {
-                truncatedText = originalText.split(' ').splice(0, parameters[1].words).join(' ');
+                truncatedText = parameters[0].split(' ').splice(0, parameters[1].words).join(' ');
               } else if (Object.prototype.hasOwnProperty.call(parameters[1], 'characters') && parameters[1].characters) {
-                truncatedText = originalText.slice(0, parameters[1].characters);
+                truncatedText = parameters[0].slice(0, parameters[1].characters);
               } else {
-                truncatedText = originalText;
+                truncatedText = parameters[0];
               }
             } // Only append the ellipsis if the text was truncated
 
 
-            if (truncatedText.length < originalText.length) {
+            if (truncatedText.length < parameters[0].length) {
               return truncatedText + ellipsis;
             } else {
               return truncatedText;

--- a/dist/truncate.js
+++ b/dist/truncate.js
@@ -37,18 +37,17 @@
             }
 
             if (typeof parameters[0] !== 'string') return parameters[0];
-            var originalText = parameters[0];
             var truncatedText;
             var ellipsis = '…'; // If the second parameter isn't truthy, return the full string
 
-            if (!parameters[1]) return originalText; // if only a number or string is passed in, keep it simple
+            if (!parameters[1]) return parameters[0]; // if only a number or string is passed in, keep it simple
 
             if (typeof parameters[1] !== 'object') {
               if (typeof parameters[2] !== 'undefined') {
                 ellipsis = parameters[2];
               }
 
-              truncatedText = originalText.slice(0, parameters[1]);
+              truncatedText = parameters[0].slice(0, parameters[1]);
             } else {
               // Customize the …
               if (Object.prototype.hasOwnProperty.call(parameters[1], 'ellipsis')) {
@@ -58,16 +57,16 @@
 
 
               if (Object.prototype.hasOwnProperty.call(parameters[1], 'words') && parameters[1].words) {
-                truncatedText = originalText.split(' ').splice(0, parameters[1].words).join(' ');
+                truncatedText = parameters[0].split(' ').splice(0, parameters[1].words).join(' ');
               } else if (Object.prototype.hasOwnProperty.call(parameters[1], 'characters') && parameters[1].characters) {
-                truncatedText = originalText.slice(0, parameters[1].characters);
+                truncatedText = parameters[0].slice(0, parameters[1].characters);
               } else {
-                truncatedText = originalText;
+                truncatedText = parameters[0];
               }
             } // Only append the ellipsis if the text was truncated
 
 
-            if (truncatedText.length < originalText.length) {
+            if (truncatedText.length < parameters[0].length) {
               return truncatedText + ellipsis;
             } else {
               return truncatedText;

--- a/dist/truncate.js
+++ b/dist/truncate.js
@@ -37,33 +37,41 @@
             }
 
             if (typeof parameters[0] !== 'string') return parameters[0];
+            var originalText = parameters[0];
+            var truncatedText;
             var ellipsis = '…'; // If the second parameter isn't truthy, return the full string
 
-            if (!parameters[1]) return parameters[0]; // if only a number or string is passed in, keep it simple
+            if (!parameters[1]) return originalText; // if only a number or string is passed in, keep it simple
 
             if (typeof parameters[1] !== 'object') {
               if (typeof parameters[2] !== 'undefined') {
                 ellipsis = parameters[2];
               }
 
-              return parameters[0].slice(0, parameters[1]) + ellipsis;
-            } // Customize the …
+              truncatedText = originalText.slice(0, parameters[1]);
+            } else {
+              // Customize the …
+              if (Object.prototype.hasOwnProperty.call(parameters[1], 'ellipsis')) {
+                ellipsis = parameters[1].ellipsis;
+              } // If words or characters is set, also check that they are truthy.
+              // Setting to 0, for example, should show all
 
 
-            if (Object.prototype.hasOwnProperty.call(parameters[1], 'ellipsis')) {
-              ellipsis = parameters[1].ellipsis;
-            } // If words or characters is set, also check that they are truthy. Setting to 0, for example, shoudld show all
+              if (Object.prototype.hasOwnProperty.call(parameters[1], 'words') && parameters[1].words) {
+                truncatedText = originalText.split(' ').splice(0, parameters[1].words).join(' ');
+              } else if (Object.prototype.hasOwnProperty.call(parameters[1], 'characters') && parameters[1].characters) {
+                truncatedText = originalText.slice(0, parameters[1].characters);
+              } else {
+                truncatedText = originalText;
+              }
+            } // Only append the ellipsis if the text was truncated
 
 
-            if (Object.prototype.hasOwnProperty.call(parameters[1], 'words') && parameters[1].words) {
-              return parameters[0].split(' ').splice(0, parameters[1].words).join(' ') + ellipsis;
+            if (truncatedText.length < originalText.length) {
+              return truncatedText + ellipsis;
+            } else {
+              return truncatedText;
             }
-
-            if (Object.prototype.hasOwnProperty.call(parameters[1], 'characters') && parameters[1].characters) {
-              return parameters[0].slice(0, parameters[1].characters) + ellipsis;
-            }
-
-            return parameters[0];
           };
         });
       }

--- a/dist/truncate.js
+++ b/dist/truncate.js
@@ -29,6 +29,8 @@
 
     var AlpineTruncateMagicMethod = {
       start: function start() {
+        var _this = this;
+
         checkForAlpine();
         Alpine.addMagicProperty('truncate', function () {
           return function () {
@@ -36,43 +38,41 @@
               parameters[_key] = arguments[_key];
             }
 
-            if (typeof parameters[0] !== 'string') return parameters[0];
-            var truncatedText;
-            var ellipsis = '…'; // If the second parameter isn't truthy, return the full string
+            if (typeof parameters[0] !== 'string') return parameters[0]; // If the second parameter isn't truthy, return the full string
 
             if (!parameters[1]) return parameters[0]; // if only a number or string is passed in, keep it simple
 
             if (typeof parameters[1] !== 'object') {
-              if (typeof parameters[2] !== 'undefined') {
-                ellipsis = parameters[2];
-              }
-
-              truncatedText = parameters[0].slice(0, parameters[1]);
-            } else {
-              // Customize the …
-              if (Object.prototype.hasOwnProperty.call(parameters[1], 'ellipsis')) {
-                ellipsis = parameters[1].ellipsis;
-              } // If words or characters is set, also check that they are truthy.
-              // Setting to 0, for example, should show all
+              return _this.appendEllipsis(parameters[0].slice(0, parameters[1]), parameters);
+            } // If words or characters is set, also check that they are truthy. Setting to 0, for example, shoudld show all
 
 
-              if (Object.prototype.hasOwnProperty.call(parameters[1], 'words') && parameters[1].words) {
-                truncatedText = parameters[0].split(' ').splice(0, parameters[1].words).join(' ');
-              } else if (Object.prototype.hasOwnProperty.call(parameters[1], 'characters') && parameters[1].characters) {
-                truncatedText = parameters[0].slice(0, parameters[1].characters);
-              } else {
-                truncatedText = parameters[0];
-              }
-            } // Only append the ellipsis if the text was truncated
-
-
-            if (truncatedText.length < parameters[0].length) {
-              return truncatedText + ellipsis;
-            } else {
-              return truncatedText;
+            if (Object.prototype.hasOwnProperty.call(parameters[1], 'words') && parameters[1].words) {
+              return _this.appendEllipsis(parameters[0].split(' ').splice(0, parameters[1].words).join(' '), parameters);
             }
+
+            if (Object.prototype.hasOwnProperty.call(parameters[1], 'characters') && parameters[1].characters) {
+              return _this.appendEllipsis(parameters[0].slice(0, parameters[1].characters), parameters);
+            }
+
+            return parameters[0];
           };
         });
+      },
+      appendEllipsis: function appendEllipsis(string, parameters) {
+        if (parameters[0].length <= string.length) return string;
+        var ellipsis = '…'; // 3rd parameter is an optional '…' override (soon to be deprecated)
+
+        if (typeof parameters[2] !== 'undefined') {
+          ellipsis = parameters[2];
+        } // If the second parameter is an object
+
+
+        if (Object.prototype.hasOwnProperty.call(parameters[1], 'ellipsis')) {
+          ellipsis = parameters[1].ellipsis;
+        }
+
+        return string + ellipsis;
       }
     };
 

--- a/src/truncate.js
+++ b/src/truncate.js
@@ -7,19 +7,18 @@ const AlpineTruncateMagicMethod = {
         Alpine.addMagicProperty('truncate', function () {
             return (...parameters) => {
                 if (typeof parameters[0] !== 'string') return parameters[0]
-                const originalText = parameters[0]
                 let truncatedText
                 let ellipsis = '…'
 
                 // If the second parameter isn't truthy, return the full string
-                if (!parameters[1]) return originalText
+                if (!parameters[1]) return parameters[0]
 
                 // if only a number or string is passed in, keep it simple
                 if (typeof parameters[1] !== 'object') {
                     if (typeof parameters[2] !== 'undefined') {
                         ellipsis = parameters[2]
                     }
-                    truncatedText = originalText.slice(0, parameters[1])
+                    truncatedText = parameters[0].slice(0, parameters[1])
                 } else {
                     // Customize the …
                     if (Object.prototype.hasOwnProperty.call(parameters[1], 'ellipsis')) {
@@ -29,16 +28,16 @@ const AlpineTruncateMagicMethod = {
                     // If words or characters is set, also check that they are truthy.
                     // Setting to 0, for example, should show all
                     if (Object.prototype.hasOwnProperty.call(parameters[1], 'words') && parameters[1].words) {
-                        truncatedText = originalText.split(' ').splice(0, parameters[1].words).join(' ')
+                        truncatedText = parameters[0].split(' ').splice(0, parameters[1].words).join(' ')
                     } else if (Object.prototype.hasOwnProperty.call(parameters[1], 'characters') && parameters[1].characters) {
-                        truncatedText = originalText.slice(0, parameters[1].characters)
+                        truncatedText = parameters[0].slice(0, parameters[1].characters)
                     } else {
-                        truncatedText = originalText
+                        truncatedText = parameters[0]
                     }
                 }
 
                 // Only append the ellipsis if the text was truncated
-                if (truncatedText.length < originalText.length) {
+                if (truncatedText.length < parameters[0].length) {
                     return truncatedText + ellipsis
                 } else {
                     return truncatedText

--- a/src/truncate.js
+++ b/src/truncate.js
@@ -7,32 +7,42 @@ const AlpineTruncateMagicMethod = {
         Alpine.addMagicProperty('truncate', function () {
             return (...parameters) => {
                 if (typeof parameters[0] !== 'string') return parameters[0]
+                const originalText = parameters[0]
+                let truncatedText
                 let ellipsis = '…'
 
                 // If the second parameter isn't truthy, return the full string
-                if (!parameters[1]) return parameters[0]
+                if (!parameters[1]) return originalText
 
                 // if only a number or string is passed in, keep it simple
                 if (typeof parameters[1] !== 'object') {
                     if (typeof parameters[2] !== 'undefined') {
                         ellipsis = parameters[2]
                     }
-                    return parameters[0].slice(0, parameters[1]) + ellipsis
+                    truncatedText = originalText.slice(0, parameters[1])
+                } else {
+                    // Customize the …
+                    if (Object.prototype.hasOwnProperty.call(parameters[1], 'ellipsis')) {
+                        ellipsis = parameters[1].ellipsis
+                    }
+
+                    // If words or characters is set, also check that they are truthy.
+                    // Setting to 0, for example, should show all
+                    if (Object.prototype.hasOwnProperty.call(parameters[1], 'words') && parameters[1].words) {
+                        truncatedText = originalText.split(' ').splice(0, parameters[1].words).join(' ')
+                    } else if (Object.prototype.hasOwnProperty.call(parameters[1], 'characters') && parameters[1].characters) {
+                        truncatedText = originalText.slice(0, parameters[1].characters)
+                    } else {
+                        truncatedText = originalText
+                    }
                 }
 
-                // Customize the …
-                if (Object.prototype.hasOwnProperty.call(parameters[1], 'ellipsis')) {
-                    ellipsis = parameters[1].ellipsis
+                // Only append the ellipsis if the text was truncated
+                if (truncatedText.length < originalText.length) {
+                    return truncatedText + ellipsis
+                } else {
+                    return truncatedText
                 }
-
-                // If words or characters is set, also check that they are truthy. Setting to 0, for example, shoudld show all
-                if (Object.prototype.hasOwnProperty.call(parameters[1], 'words') && parameters[1].words) {
-                    return parameters[0].split(' ').splice(0, parameters[1].words).join(' ') + ellipsis
-                }
-                if (Object.prototype.hasOwnProperty.call(parameters[1], 'characters') && parameters[1].characters) {
-                    return parameters[0].slice(0, parameters[1].characters) + ellipsis
-                }
-                return parameters[0]
             }
         })
     },

--- a/src/truncate.js
+++ b/src/truncate.js
@@ -4,46 +4,41 @@ const AlpineTruncateMagicMethod = {
     start() {
         checkForAlpine()
 
-        Alpine.addMagicProperty('truncate', function () {
+        Alpine.addMagicProperty('truncate', () => {
             return (...parameters) => {
                 if (typeof parameters[0] !== 'string') return parameters[0]
-                let truncatedText
-                let ellipsis = '…'
 
                 // If the second parameter isn't truthy, return the full string
                 if (!parameters[1]) return parameters[0]
 
                 // if only a number or string is passed in, keep it simple
                 if (typeof parameters[1] !== 'object') {
-                    if (typeof parameters[2] !== 'undefined') {
-                        ellipsis = parameters[2]
-                    }
-                    truncatedText = parameters[0].slice(0, parameters[1])
-                } else {
-                    // Customize the …
-                    if (Object.prototype.hasOwnProperty.call(parameters[1], 'ellipsis')) {
-                        ellipsis = parameters[1].ellipsis
-                    }
-
-                    // If words or characters is set, also check that they are truthy.
-                    // Setting to 0, for example, should show all
-                    if (Object.prototype.hasOwnProperty.call(parameters[1], 'words') && parameters[1].words) {
-                        truncatedText = parameters[0].split(' ').splice(0, parameters[1].words).join(' ')
-                    } else if (Object.prototype.hasOwnProperty.call(parameters[1], 'characters') && parameters[1].characters) {
-                        truncatedText = parameters[0].slice(0, parameters[1].characters)
-                    } else {
-                        truncatedText = parameters[0]
-                    }
+                    return this.appendEllipsis(parameters[0].slice(0, parameters[1]), parameters)
                 }
 
-                // Only append the ellipsis if the text was truncated
-                if (truncatedText.length < parameters[0].length) {
-                    return truncatedText + ellipsis
-                } else {
-                    return truncatedText
+                // If words or characters is set, also check that they are truthy. Setting to 0, for example, shoudld show all
+                if (Object.prototype.hasOwnProperty.call(parameters[1], 'words') && parameters[1].words) {
+                    return this.appendEllipsis(parameters[0].split(' ').splice(0, parameters[1].words).join(' '), parameters)
                 }
+                if (Object.prototype.hasOwnProperty.call(parameters[1], 'characters') && parameters[1].characters) {
+                    return this.appendEllipsis(parameters[0].slice(0, parameters[1].characters), parameters)
+                }
+                return parameters[0]
             }
         })
+    },
+    appendEllipsis(string, parameters) {
+        if (parameters[0].length <= string.length) return string
+        let ellipsis = '…'
+        // 3rd parameter is an optional '…' override (soon to be deprecated)
+        if (typeof parameters[2] !== 'undefined') {
+            ellipsis = parameters[2]
+        }
+        // If the second parameter is an object
+        if (Object.prototype.hasOwnProperty.call(parameters[1], 'ellipsis')) {
+            ellipsis = parameters[1].ellipsis
+        }
+        return string + ellipsis
     },
 }
 

--- a/tests/truncate.spec.js
+++ b/tests/truncate.spec.js
@@ -46,6 +46,18 @@ test('$truncate > can shorten text with custom suffix', () => {
     expect(document.querySelector('p').textContent).toEqual('Lorem (read more)')
 })
 
+test('$truncate > will append the ellipsis only if text was truncated', () => {
+    document.body.innerHTML = `
+        <div x-data="{ characters: 11, string: 'Lorem ipsum'}">
+            <p x-text="$truncate(string, characters)"></p>
+        </div>
+    `
+
+    Alpine.start()
+
+    expect(document.querySelector('p').textContent).toEqual('Lorem ipsum')
+})
+
 test('$truncate > will react to changes in arguments', async () => {
     document.body.innerHTML = `
         <div x-data="{ characters: 5, string: 'Lorem ipsum'}">


### PR DESCRIPTION
The `truncate` magic helper should only append the ellipsis (...) at the end if the text was actually truncated.