### PR TITLE
Misc/better CI

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -24,6 +24,21 @@ jobs:
         run: git config --global user.name ${GITHUB_ACTOR}@users.noreply.github.com
       - name: Install dependencies
         run: npm ci
+      - name: Disable branch protection on master
+        uses: octokit/request-action@v2.x
+        with:
+            route: PUT /repos/:repository/branches/master/protection
+            repository: ${{ github.repository }}
+            enforce_admins: |
+                null
+            required_status_checks: |
+                null
+            required_pull_request_reviews: |
+                null
+            restrictions: |
+                null
+            env:
+                GITHUB_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
       - name: Build dist folder
         run: npm run build
       - name: Commit dist folder if needed #it fails if nothing has changed so we allow an error
@@ -48,6 +63,24 @@ jobs:
         run: git tag -f $RELEASE_VERSION
       - name: Update remote tag
         run: git push --tags --force
+      - name: Re-eanable branch protection on master
+        uses: octokit/request-action@v2.x
+        with:
+            route: PUT /repos/:repository/branches/master/protection
+            repository: ${{ github.repository }}
+            enforce_admins: |
+                true
+            required_status_checks: |
+                strict: true
+                contexts:
+                  - build (12.x)
+            required_pull_request_reviews: |
+                dismiss_stale_reviews: true
+                require_code_owner_reviews: true
+            restrictions: |
+                null
+            env:
+                GITHUB_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
       - name: Publish to npm
         run: npm publish --access public
         env:

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -37,8 +37,8 @@ jobs:
                 null
             restrictions: |
                 null
-            env:
-                GITHUB_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+        env:
+            GITHUB_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
       - name: Build dist folder
         run: npm run build
       - name: Commit dist folder if needed #it fails if nothing has changed so we allow an error
@@ -79,8 +79,8 @@ jobs:
                 require_code_owner_reviews: true
             restrictions: |
                 null
-            env:
-                GITHUB_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+        env:
+            GITHUB_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
       - name: Publish to npm
         run: npm publish --access public
         env:


### PR DESCRIPTION
Updated the workflow to relax the protection settings on the master branch when tagging and revert them back at the end.
Since the user who tags the release is an admin and the action runs as that user, it should be allowed to push changes.
I've already added the admin token into the secrets section