### PR TITLE
[Wip][Feature] Add teleport helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Adds the following magic helpers to use with Alpine JS. ***More to come!***
 | [`$range`](#range) | Iterate over a range of values. |
 | [`$screen`](#screen) | Detect if the current browser width is equal or greater than a given breakpoint. |
 | [`$scroll`](#scroll) | Scroll the page vertically to a specific position. |
+| [`$teleport`](#teleport) |  Appends/Prepends a component/node element to any where in the DOM. |
 | [`$truncate`](#truncate) |  Limit a text string to a specific number of characters or words. |
 
 🚀 If you have ideas for more magic helpers, please open a [discussion](https://github.com/alpine-collective/alpine-magic-helpers/discussions) or join us on the [AlpineJS Discord](https://discord.gg/snmCYk3)
@@ -36,6 +37,7 @@ Or only use the specific methods you need:
 <script src="https://cdn.jsdelivr.net/gh/alpine-collective/alpine-magic-helpers@0.5.x/dist/range.min.js"></script>
 <script src="https://cdn.jsdelivr.net/gh/alpine-collective/alpine-magic-helpers@0.5.x/dist/screen.min.js"></script>
 <script src="https://cdn.jsdelivr.net/gh/alpine-collective/alpine-magic-helpers@0.5.x/dist/scroll.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/alpine-collective/alpine-magic-helpers@0.5.x/dist/teleport.min.js"></script>
 <script src="https://cdn.jsdelivr.net/gh/alpine-collective/alpine-magic-helpers@0.5.x/dist/truncate.min.js"></script>
 ```
 
@@ -313,6 +315,93 @@ With both:
 <button x-data x-on:click="$scroll(0, {behavior: auto, offset: 50}">Jump to 50px before top</scroll>
 ```
 [Demo](https://codepen.io/KevinBatdorf/pen/PozVLPy?editors=1000) (same as above)
+
+---
+
+### `$teleport`
+Teleports (`appends/prepends`) a component/node element to any where in the DOM
+
+*Defaults*
+**$teleport(from = $el, to = document.body, options = { prepend: false })**
+
+`destination` may defined as CSS selector or node.
+```html
+//tag
+<div x-init="() => $teleport('<div>Text<div>', 'div')">
+
+//id
+<div x-init="() => $teleport('<div>Text<div>', '#destination')">
+
+//class
+<div x-init="() => $teleport('<div>Text<div>', '.destination')">
+
+//atribute
+<div x-init="() => $teleport('<div>Text<div>', '[destination]')">
+
+//reference
+<div x-init="() => $teleport('<div>Text<div>', $refs.destination)">
+```
+
+*Note: Make sure to call it as arrow function if you use in `x-init`:*
+```html
+// if on x-init use arrow function
+x-init="() => $teleport(...)
+
+// if on events use it plain
+x-on:click="$teleport(...)"
+x-on:custom-event="$teleport(...)"
+```
+
+**Example:**
+
+```html
+<div x-data x-init="() => $teleport($el, '#destination')">
+  Teleporter
+</div>
+<div id="destination">
+  <h2>Element down below is teleported</h2>
+</div>
+
+```
+
+You may also pass teleporter element as `x-ref` reference or even as string to second argument:
+
+```html
+<div x-data x-init="() =>  { $teleport($refs.teleporter, '#destination-1'), $teleport('Teleporter 2', '#destination-2') }">
+  <h3 x-ref="teleporter">Teleporter 1</h3>
+</div>
+
+<div id="destination-1">
+  <h2>Element down below is teleported</h2>
+</div>
+<div x-portal="destination-2">
+  <h2>Text down below is teleported</h2>
+</div>
+```
+
+If you want to prepend to target destination, you may pass the options argument as `true`:
+
+```html
+<div x-data x-init="() => $teleport($refs.teleporter, '#destination', { prepend: true })">
+  <h3 x-ref="teleporter">Teleporter</h3>
+</div>
+<div id="destination">
+  <h2>Element above is teleported</h2>
+</div>
+```
+
+All events / props / computed values are carried with teleport:
+
+```html
+<div x-data="{show: true}" x-init="() => $teleport($refs.teleporter, '#destination')">
+  <button x-ref="teleporter" x-on:click="alert('teleported')" x-show="show">Alert</button>
+</div>
+<div id="destination">
+  <h2>Element below is teleported and it carried its events</h2>
+</div>
+```
+
+[Demo](https://codepen.io/muzafferdede/pen/eYzwmwE)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -364,10 +364,10 @@ x-on:custom-event="$teleport(...)"
 
 ```
 
-You may also pass teleporter element as `x-ref` reference or even as string to second argument:
+You may also pass teleporter element as node reference or even as string template:
 
 ```html
-<div x-data x-init="() =>  { $teleport($refs.teleporter, '#destination-1'), $teleport('Teleporter 2', '#destination-2') }">
+<div x-data x-init="() =>  { $teleport($refs.teleporter, '#destination-1'), $teleport('<div>Teleporter</div>', '#destination-2') }">
   <h3 x-ref="teleporter">Teleporter 1</h3>
 </div>
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -2352,6 +2352,61 @@
       alpine$5(callback);
     };
 
+    var AlpineTeleportMagicMethod = {
+      start: function start() {
+        checkForAlpine();
+        Alpine.addMagicProperty('teleport', function ($el) {
+          return function (from, to, options) {
+            if (from === void 0) {
+              from = $el;
+            }
+
+            if (to === void 0) {
+              to = document.body;
+            }
+
+            if (options === void 0) {
+              options = {
+                prepend: false
+              };
+            }
+
+            // Figure out element that needs to be teleported
+            var element = typeof from === 'string' ? document.createRange().createContextualFragment(from) : from; // Figure out destination
+
+            var target = typeof to === 'string' ? document.querySelector(to) : to; // Check if destination is exists
+
+            if (!target) {
+              throw Error("Destination \"" + to + "\" not found. Does your element have proper attribute?");
+            } // Set mutation to sync initial component data if element is not a component
+
+
+            if (!element.__x) {
+              updateOnMutation($el, function () {
+                syncWithObservedComponent($el.__x.getUnobservedData(), $el, objectSetDeep);
+
+                $el.__x.updateElements(element);
+              });
+            } // Prepend element to destination if 'prepend' option is set to true
+
+
+            if (options.prepend) return target.prepend(element); // Append element to destination
+
+            target.append(element);
+          };
+        });
+      }
+    };
+
+    var alpine$6 = window.deferLoadingAlpine || function (alpine) {
+      return alpine();
+    };
+
+    window.deferLoadingAlpine = function (callback) {
+      AlpineTeleportMagicMethod.start();
+      alpine$6(callback);
+    };
+
     var AlpineTruncateMagicMethod = {
       start: function start() {
         var _this = this;
@@ -2401,13 +2456,13 @@
       }
     };
 
-    var alpine$6 = window.deferLoadingAlpine || function (alpine) {
+    var alpine$7 = window.deferLoadingAlpine || function (alpine) {
       return alpine();
     };
 
     window.deferLoadingAlpine = function (callback) {
       AlpineTruncateMagicMethod.start();
-      alpine$6(callback);
+      alpine$7(callback);
     };
 
     var index = {
@@ -2417,6 +2472,7 @@
       AlpineRangeMagicMethod: AlpineRangeMagicMethod,
       AlpineScreenMagicMethod: AlpineScreenMagicMethod,
       AlpineScrollMagicMethod: AlpineScrollMagicMethod,
+      AlpineTeleportMagicMethod: AlpineTeleportMagicMethod,
       AlpineTruncateMagicMethod: AlpineTruncateMagicMethod
     };
 

--- a/dist/teleport.js
+++ b/dist/teleport.js
@@ -1,0 +1,156 @@
+(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+    typeof define === 'function' && define.amd ? define(factory) :
+    (global = typeof globalThis !== 'undefined' ? globalThis : global || self, (global.AlpineMagicHelpers = global.AlpineMagicHelpers || {}, global.AlpineMagicHelpers.teleport = factory()));
+}(this, (function () { 'use strict';
+
+    var checkForAlpine = function checkForAlpine() {
+      if (!window.Alpine) {
+        throw new Error('[Magic Helpers] Alpine is required for the magic helpers to function correctly.');
+      }
+
+      if (!window.Alpine.version || !isValidVersion('2.5.0', window.Alpine.version)) {
+        throw new Error('Invalid Alpine version. Please use Alpine version 2.5.0 or above');
+      }
+    };
+    var syncWithObservedComponent = function syncWithObservedComponent(data, observedComponent, callback) {
+      if (!observedComponent.getAttribute('x-bind:data-last-refresh')) {
+        observedComponent.setAttribute('x-bind:data-last-refresh', 'Date.now()');
+      }
+
+      var handler = function handler(scope) {
+        if (scope === void 0) {
+          scope = null;
+        }
+
+        return {
+          get: function get(target, key) {
+            if (target[key] !== null && typeof target[key] === 'object') {
+              var path = scope ? scope + "." + key : key;
+              return new Proxy(target[key], handler(path));
+            }
+
+            return target[key];
+          },
+          set: function set(_target, key, value) {
+            if (!observedComponent.__x) {
+              throw new Error('Error communicating with observed component');
+            }
+
+            var path = scope ? scope + "." + key : key;
+            callback.call(observedComponent, observedComponent.__x.$data, path, value);
+            return true;
+          }
+        };
+      };
+
+      return new Proxy(data, handler());
+    };
+    var updateOnMutation = function updateOnMutation(componentBeingObserved, callback) {
+      if (!componentBeingObserved.getAttribute('x-bind:data-last-refresh')) {
+        componentBeingObserved.setAttribute('x-bind:data-last-refresh', 'Date.now()');
+      }
+
+      var observer = new MutationObserver(function (mutations) {
+        for (var i = 0; i < mutations.length; i++) {
+          var mutatedComponent = mutations[i].target.closest('[x-data]');
+          if (mutatedComponent && !mutatedComponent.isSameNode(componentBeingObserved)) continue;
+          callback();
+          return;
+        }
+      });
+      observer.observe(componentBeingObserved, {
+        attributes: true,
+        childList: true,
+        subtree: true
+      });
+    }; // Borrowed from https://stackoverflow.com/a/54733755/1437789
+
+    var objectSetDeep = function objectSetDeep(object, path, value) {
+      path = path.toString().match(/[^.[\]]+/g) || []; // Iterate all of them except the last one
+
+      path.slice(0, -1).reduce(function (a, currentKey, index) {
+        // If the key does not exist or its value is not an object, create/override the key
+        if (Object(a[currentKey]) !== a[currentKey]) {
+          // Is the next key a potential array-index?
+          a[currentKey] = Math.abs(path[index + 1]) >> 0 === +path[index + 1] ? [] // Yes: assign a new array object
+          : {}; // No: assign a new plain object
+        }
+
+        return a[currentKey];
+      }, object)[path[path.length - 1]] = value; // Finally assign the value to the last key
+
+      return object;
+    }; // Returns component data if Alpine has made it available, otherwise computes it with saferEval()
+
+    function isValidVersion(required, current) {
+      var requiredArray = required.split('.');
+      var currentArray = current.split('.');
+
+      for (var i = 0; i < requiredArray.length; i++) {
+        if (!currentArray[i] || parseInt(currentArray[i]) < parseInt(requiredArray[i])) {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    var AlpineTeleportMagicMethod = {
+      start: function start() {
+        checkForAlpine();
+        Alpine.addMagicProperty('teleport', function ($el) {
+          return function (from, to, options) {
+            if (from === void 0) {
+              from = $el;
+            }
+
+            if (to === void 0) {
+              to = document.body;
+            }
+
+            if (options === void 0) {
+              options = {
+                prepend: false
+              };
+            }
+
+            // Figure out element that needs to be teleported
+            var element = typeof from === 'string' ? document.createRange().createContextualFragment(from) : from; // Figure out destination
+
+            var target = typeof to === 'string' ? document.querySelector(to) : to; // Check if destination is exists
+
+            if (!target) {
+              throw Error("Destination \"" + to + "\" not found. Does your element have proper attribute?");
+            } // Set mutation to sync initial component data if element is not a component
+
+
+            if (!element.__x) {
+              updateOnMutation($el, function () {
+                syncWithObservedComponent($el.__x.getUnobservedData(), $el, objectSetDeep);
+
+                $el.__x.updateElements(element);
+              });
+            } // Prepend element to destination if 'prepend' option is set to true
+
+
+            if (options.prepend) return target.prepend(element); // Append element to destination
+
+            target.append(element);
+          };
+        });
+      }
+    };
+
+    var alpine = window.deferLoadingAlpine || function (alpine) {
+      return alpine();
+    };
+
+    window.deferLoadingAlpine = function (callback) {
+      AlpineTeleportMagicMethod.start();
+      alpine(callback);
+    };
+
+    return AlpineTeleportMagicMethod;
+
+})));

--- a/examples/index.html
+++ b/examples/index.html
@@ -98,6 +98,16 @@
     </div>
 
     <div class="mt-4 pt-4 border-t">
+        <h2 class="text-2xl font-black">$teleport:</h2>
+        <p class="mb-4">Teleports an element to any were in the DOM even if target is not an alpine component</p>
+        <div x-data="{count: 0}" x-init="() => $teleport($refs.teleporter, '#teleportDestination')">
+            <button x-text="count" x-on:click="count++"></button>
+            <button x-ref="teleporter" x-on:click="count++" x-text="count">test</div>
+        </div>
+        <div id="teleportDestination"></div>
+    </div>
+
+    <div class="mt-4 pt-4 border-t">
         <h2 class="text-2xl font-black">$truncate:</h2>
         <p class="mb-4">Truncate to specific characters (click the truncated text to update from 50 characters to unlimited)</p>
         <div

--- a/examples/index.html
+++ b/examples/index.html
@@ -100,9 +100,9 @@
     <div class="mt-4 pt-4 border-t">
         <h2 class="text-2xl font-black">$teleport:</h2>
         <p class="mb-4">Teleports an element to any were in the DOM even if target is not an alpine component</p>
-        <div x-data="{count: 0}" x-init="() => $teleport($refs.teleporter, '#teleportDestination')">
+        <div x-data="{count: 0, show: true}" x-init="() => $teleport($refs.teleporter, '#teleportDestination')">
             <button x-text="count" x-on:click="count++"></button>
-            <button x-ref="teleporter" x-on:click="count++" x-text="count">test</div>
+            <button x-ref="teleporter" x-on:click="count++" x-text="count" x-show="show">test</div>
         </div>
         <div id="teleportDestination"></div>
     </div>

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "src/range.js",
         "src/screen.js",
         "src/scroll.js",
+        "src/teleport.js",
         "src/truncate.js"
     ],
     "main": "dist/index.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -44,5 +44,6 @@ export default [
     'range',
     'screen',
     'scroll',
+    'teleport',
     'truncate',
 ].map(createConfig)

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import AlpineIntervalMagicMethod from './interval'
 import AlpineRangeMagicMethod from './range'
 import AlpineScreenMagicMethod from './screen'
 import AlpineScrollMagicMethod from './scroll'
+import AlpineTeleportMagicMethod from './teleport'
 import AlpineTruncateMagicMethod from './truncate'
 
 export default {
@@ -13,5 +14,6 @@ export default {
     AlpineRangeMagicMethod,
     AlpineScreenMagicMethod,
     AlpineScrollMagicMethod,
+    AlpineTeleportMagicMethod,
     AlpineTruncateMagicMethod,
 }

--- a/src/teleport.js
+++ b/src/teleport.js
@@ -1,0 +1,52 @@
+import {
+    checkForAlpine,
+    objectSetDeep,
+    syncWithObservedComponent,
+    updateOnMutation,
+} from './utils'
+
+const AlpineTeleportMagicMethod = {
+    start() {
+        checkForAlpine()
+        Alpine.addMagicProperty('teleport', ($el) => {
+            return (from = $el, to = document.body, options = { prepend: false }) => {
+                // Figure out element that needs to be teleported
+                const element = typeof from === 'string'
+                    ? document.createRange().createContextualFragment(from)
+                    : from
+
+                // Figure out destination
+                const target = typeof to === 'string'
+                    ? document.querySelector(to)
+                    : to
+
+                // Check if destination is exists
+                if (!target) {
+                    throw Error(`Destination "${to}" not found. Does your element have proper attribute?`)
+                }
+
+                // Set mutation to sync initial component data if element is not a component
+                if (!element.__x) {
+                    updateOnMutation($el, () => {
+                        syncWithObservedComponent($el.__x.getUnobservedData(), $el, objectSetDeep)
+                        $el.__x.updateElements(element)
+                    })
+                }
+
+                // Prepend element to destination if 'prepend' option is set to true
+                if (options.prepend) return target.prepend(element)
+
+                // Append element to destination
+                target.append(element)
+            }
+        })
+    },
+}
+
+const alpine = window.deferLoadingAlpine || ((alpine) => alpine())
+window.deferLoadingAlpine = (callback) => {
+    AlpineTeleportMagicMethod.start()
+    alpine(callback)
+}
+
+export default AlpineTeleportMagicMethod

--- a/src/teleport.js
+++ b/src/teleport.js
@@ -29,6 +29,7 @@ const AlpineTeleportMagicMethod = {
                 if (!element.__x) {
                     updateOnMutation($el, () => {
                         syncWithObservedComponent($el.__x.getUnobservedData(), $el, objectSetDeep)
+
                         $el.__x.updateElements(element)
                     })
                 }

--- a/tests/teleport.spec.js
+++ b/tests/teleport.spec.js
@@ -1,0 +1,89 @@
+import Alpine from 'alpinejs'
+import AlpineTeleportMagicMethod from '../dist/teleport'
+import { waitFor } from '@testing-library/dom'
+
+beforeAll(() => {
+    window.Alpine = Alpine
+})
+
+beforeEach(() => {
+    AlpineTeleportMagicMethod.start()
+})
+
+test('$teleport > can teleport elements to target destination on the DOM', async () => {
+    document.body.innerHTML = `
+        <span x-data x-init="() => $teleport($el,'#destination')">Teleporter</span>
+        <div id="destination"></div>
+    `
+
+    Alpine.start()
+
+    await waitFor(() => {
+        expect(document.querySelector('#destination').firstChild.textContent).toEqual('Teleporter')
+    })
+})
+
+test('$teleport > can teleport x-ref elements to target destination on the DOM', async () => {
+    document.body.innerHTML = `
+      <span x-data x-init="() => $teleport($refs.teleporter,'#destination')">
+        <span x-ref="teleporter">Teleporter</span>
+      </span>
+      <div id="destination"></div>
+  `
+
+    Alpine.start()
+
+    await waitFor(() => {
+        expect(document.querySelector('#destination').firstChild.textContent).toEqual('Teleporter')
+    })
+})
+
+test('$teleport > can teleport strings to target destination on the DOM', async () => {
+    document.body.innerHTML = `
+      <span x-data x-init="() => $teleport('Teleporter','#destination')"></span>
+      <div id="destination"></div>
+  `
+
+    Alpine.start()
+
+    await waitFor(() => {
+        expect(document.querySelector('#destination').textContent).toEqual('Teleporter')
+    })
+})
+
+test('$teleport > can can prepend elements', async () => {
+    document.body.innerHTML = `
+      <span x-data x-init="() => $teleport($refs.teleporter,'#destination',{prepend: true})">
+        <span x-ref="teleporter">Teleporter</span>
+      </span>
+      <div id="destination"><span>First Child</span></div>
+  `
+
+    Alpine.start()
+
+    await waitFor(() => {
+        expect(document.querySelector('#destination').firstChild.textContent).toEqual('Teleporter')
+    })
+})
+
+test('$teleport > carries events with the teleported element', async () => {
+    document.body.innerHTML = `
+      <span x-data="{text: ''}" x-init="() => $teleport($refs.teleporter, '#destination')">
+        <button x-ref="teleporter" x-on:click="text = 'Content'">Teleporter</button>
+        <p x-text="text"></p>
+      </span>
+      <div id="destination"></div>
+  `
+
+    Alpine.start()
+
+    await waitFor(() => {
+        expect(document.querySelector('#destination').firstChild.textContent).toEqual('Teleporter')
+    })
+
+    document.querySelector('button').click()
+
+    await waitFor(() => {
+        expect(document.querySelector('p').textContent).toEqual('Content')
+    })
+})

--- a/tests/teleport.spec.js
+++ b/tests/teleport.spec.js
@@ -10,23 +10,22 @@ beforeEach(() => {
     AlpineTeleportMagicMethod.start()
 })
 
-test('$teleport > can teleport elements to target destination on the DOM', async () => {
+test('$teleport > by default teleports element to body', async () => {
     document.body.innerHTML = `
-        <span x-data x-init="() => $teleport($el,'#destination')">Teleporter</span>
-        <div id="destination"></div>
+        <span x-data x-init="() => $teleport()">foo</span>
     `
 
     Alpine.start()
 
     await waitFor(() => {
-        expect(document.querySelector('#destination').firstChild.textContent).toEqual('Teleporter')
+        expect(document.querySelector('body > span').textContent).toEqual('foo')
     })
 })
 
-test('$teleport > can teleport x-ref elements to target destination on the DOM', async () => {
+test('$teleport > can teleport node elements to target destination', async () => {
     document.body.innerHTML = `
       <span x-data x-init="() => $teleport($refs.teleporter,'#destination')">
-        <span x-ref="teleporter">Teleporter</span>
+        <span x-ref="teleporter">foo</span>
       </span>
       <div id="destination"></div>
   `
@@ -34,27 +33,27 @@ test('$teleport > can teleport x-ref elements to target destination on the DOM',
     Alpine.start()
 
     await waitFor(() => {
-        expect(document.querySelector('#destination').firstChild.textContent).toEqual('Teleporter')
+        expect(document.querySelector('#destination').firstChild.textContent).toEqual('foo')
     })
 })
 
-test('$teleport > can teleport strings to target destination on the DOM', async () => {
+test('$teleport > converts a template string into HTML DOM node and teleports it to destination', async () => {
     document.body.innerHTML = `
-      <span x-data x-init="() => $teleport('Teleporter','#destination')"></span>
+      <span x-data x-init="() => $teleport('<span>foo<span>','#destination')"></span>
       <div id="destination"></div>
   `
 
     Alpine.start()
 
     await waitFor(() => {
-        expect(document.querySelector('#destination').textContent).toEqual('Teleporter')
+        expect(document.querySelector('#destination span').textContent).toEqual('foo')
     })
 })
 
 test('$teleport > can can prepend elements', async () => {
     document.body.innerHTML = `
       <span x-data x-init="() => $teleport($refs.teleporter,'#destination',{prepend: true})">
-        <span x-ref="teleporter">Teleporter</span>
+        <span x-ref="teleporter">foo</span>
       </span>
       <div id="destination"><span>First Child</span></div>
   `
@@ -62,15 +61,15 @@ test('$teleport > can can prepend elements', async () => {
     Alpine.start()
 
     await waitFor(() => {
-        expect(document.querySelector('#destination').firstChild.textContent).toEqual('Teleporter')
+        expect(document.querySelector('#destination').firstChild.textContent).toEqual('foo')
     })
 })
 
-test('$teleport > carries events with the teleported element', async () => {
+test('$teleport > carries reactivity with the teleported element even it is not a component', async () => {
     document.body.innerHTML = `
-      <span x-data="{text: ''}" x-init="() => $teleport($refs.teleporter, '#destination')">
-        <button x-ref="teleporter" x-on:click="text = 'Content'">Teleporter</button>
-        <p x-text="text"></p>
+      <span x-data="{foo: 'bar'}" x-init="() => $teleport($refs.teleporter, '#destination')">
+        <button x-ref="teleporter" x-on:click="foo='baz'" x-text="foo"></button>
+        <p x-text="foo"></p>
       </span>
       <div id="destination"></div>
   `
@@ -78,12 +77,14 @@ test('$teleport > carries events with the teleported element', async () => {
     Alpine.start()
 
     await waitFor(() => {
-        expect(document.querySelector('#destination').firstChild.textContent).toEqual('Teleporter')
+        expect(document.querySelector('button').textContent).toEqual('bar')
+        expect(document.querySelector('p').textContent).toEqual('bar')
     })
 
     document.querySelector('button').click()
 
     await waitFor(() => {
-        expect(document.querySelector('p').textContent).toEqual('Content')
+        expect(document.querySelector('button').textContent).toEqual('baz')
+        expect(document.querySelector('p').textContent).toEqual('baz')
     })
 })


### PR DESCRIPTION
This PR adds teleport helper
- Teleports element anywhere in the DOM
- Reactivity of elements and values are kept after teleport
- Target does not has to be a alpine component
- It can append or prepend
- Teleport element could be `$el`, `$refs.anything`, `'string'`
- default values are `$(target = document.body, $element = $el, prepend = false)`

** Example**
```html
      <div x-data="{content: 'hello world', show: true}" 
         x-init="$teleport('target', $refs.teleporter, true), $teleport('target', $refs.button)"
      >

        <div x-ref="teleporter">
          <div x-text="content" x-show="show"></div>
        </div>

        <button x-ref="button" x-on:click="alert('click event binded before teleport')">Alert</button>
      </div>

      // Notice that this is not an alpine component
       <div x-portal="target">
           <h2>Element down below is teleported after alpine done its updates</h2>
       </div>
```

[Demo](https://codepen.io/muzafferdede/pen/eYzwmwE)