### PR TITLE
Fix issue with helpers being registered twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Helpers were registered twice by mistake resulting in unecessary function calls.
 
 ## [0.4.1] - 2020-11-16
 ### Fixed

--- a/dist/index.js
+++ b/dist/index.js
@@ -2319,20 +2319,6 @@
       alpine$5(callback);
     };
 
-    var alpine$6 = window.deferLoadingAlpine || function (alpine) {
-      return alpine();
-    };
-
-    window.deferLoadingAlpine = function (callback) {
-      AlpineComponentMagicMethod.start();
-      AlpineFetchMagicMethod.start();
-      AlpineIntervalMagicMethod.start();
-      AlpineRangeMagicMethod.start();
-      AlpineScrollMagicMethod.start();
-      AlpineTruncateMagicMethod.start();
-      alpine$6(callback);
-    };
-
     var index = {
       AlpineComponentMagicMethod: AlpineComponentMagicMethod,
       AlpineFetchMagicMethod: AlpineFetchMagicMethod,

--- a/examples/index.html
+++ b/examples/index.html
@@ -37,7 +37,7 @@
         <div x-data>
             <p x-ref="myref">myref</p>
             <button x-on:click="$scroll(0)" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">Scroll to top</button>
-            <button x-on:click="$scroll('#yellowsquare')" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">Scroll to ID yellowsuare</button>
+            <button x-on:click="$scroll('#yellowsquare')" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">Scroll to ID yellowsquare</button>
             <button x-on:click="$scroll($refs.myref)" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">Scroll to myref</button>
             <button x-on:click="$scroll($refs.myref, {offset: 50})" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">Scroll to myref with offset</button>
         </div>

--- a/src/index.js
+++ b/src/index.js
@@ -5,19 +5,6 @@ import AlpineRangeMagicMethod from './range'
 import AlpineScrollMagicMethod from './scroll'
 import AlpineTruncateMagicMethod from './truncate'
 
-const alpine = window.deferLoadingAlpine || ((alpine) => alpine())
-
-window.deferLoadingAlpine = function (callback) {
-    AlpineComponentMagicMethod.start()
-    AlpineFetchMagicMethod.start()
-    AlpineIntervalMagicMethod.start()
-    AlpineRangeMagicMethod.start()
-    AlpineScrollMagicMethod.start()
-    AlpineTruncateMagicMethod.start()
-
-    alpine(callback)
-}
-
 export default {
     AlpineComponentMagicMethod,
     AlpineFetchMagicMethod,


### PR DESCRIPTION
I just noticed looking at the compiled file that the final div includes both the call to register the helper in the corresponding file and the one in index.js.
I checked the old build and it was the same so it's not a "rollup" thing.
I think we can safely remove the one in index.js (fewer things to do for new helpers and possibly fewer bugs in the future due to duplicate start() calls).