### PR TITLE
Update github action

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -45,13 +45,13 @@ jobs:
         run: git commit -am 'Rebuild dist'
         continue-on-error: true
       - name: Read tag name
-        run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF:10}
+        run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
       - name: Delete tag #for some reason npm version fails if the tag exists
         run: git tag -d $RELEASE_VERSION
       - name: Update version in package.json
         run: npm version $RELEASE_VERSION
       - name: Generate version for cdn links
-        run: echo ::set-env name=CDN_VERSION::$(echo $RELEASE_VERSION | sed 's/v\([0-9]\)\.\([0-9]\)\.[0-9]/\1.\2.x/g')
+        run: echo "CDN_VERSION::$(echo $RELEASE_VERSION | sed 's/v\([0-9]\)\.\([0-9]\)\.[0-9]/\1.\2.x/g')" >> $GITHUB_ENV
       - name: Update README
         run: sed -i "s/[0-9]\.[0-9]\.x/$CDN_VERSION/g" README.md
       - name: Commit README if needed #it fails if nothing has changed so we allow an error


### PR DESCRIPTION
On the last release, I noticed some warnings (see https://github.com/alpine-collective/alpine-magic-helpers/actions/runs/36623148) pointing at https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Apparently, set_env which we use in our automated workflow to publish to npm) has been deprecated and it needs to be rewritten using a different syntax (more details at https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable).

I didn't add a changelog since it's not strictly related to the library.