### PR TITLE
Bug/scroll float values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [$scroll]: When using css selectors or Alpine reference, element position to scroll to was some times a decimal number (e.g. rem values could resolve to a decimal number) and $scroll was triggering an error.
 
 ## [0.5.0] - 2020-11-23
 ### Fixed

--- a/dist/index.js
+++ b/dist/index.js
@@ -2315,7 +2315,7 @@
 
 
             if (target instanceof Element) {
-              target = target.getBoundingClientRect().top + window.pageYOffset;
+              target = Math.floor(target.getBoundingClientRect().top + window.pageYOffset);
             } // If target has been converted to the y coordinate or was an object to begin with
             // we transform it to a ScrollToOptions dictionary
 

--- a/dist/scroll.js
+++ b/dist/scroll.js
@@ -478,7 +478,7 @@
 
 
 	        if (target instanceof Element) {
-	          target = target.getBoundingClientRect().top + window.pageYOffset;
+	          target = Math.floor(target.getBoundingClientRect().top + window.pageYOffset);
 	        } // If target has been converted to the y coordinate or was an object to begin with
 	        // we transform it to a ScrollToOptions dictionary
 

--- a/src/scroll.js
+++ b/src/scroll.js
@@ -27,7 +27,7 @@ const AlpineScrollMagicMethod = {
                 // This could happens if we trasform a selector or if we pass an Element in,
                 // for example using $ref['something']
                 if (target instanceof Element) {
-                    target = target.getBoundingClientRect().top + window.pageYOffset
+                    target = Math.floor(target.getBoundingClientRect().top + window.pageYOffset)
                 }
 
                 // If target has been converted to the y coordinate or was an object to begin with

--- a/tests/scroll.spec.js
+++ b/tests/scroll.spec.js
@@ -162,3 +162,29 @@ test('$scroll > can disable the smooth scrolling AND apply an offset', async () 
     // function is called correctly
     expect(window.scroll).toHaveBeenCalledWith({ behavior: 'auto', top: 60 })
 })
+
+test('$scroll > can scroll when getBoundingClientRect returns a floating number', async () => {
+    document.body.innerHTML = `
+        <div x-data>
+            <button @click="$scroll($refs.foo)"></button>
+            <p x-ref="foo" x-text="'loaded'"></p>
+        </div>
+    `
+
+    // We need to mock getBoundingClientRect since jest doesn't have a viewport
+    document.querySelector('p').getBoundingClientRect = jest.fn(() => ({
+        top: 20.756,
+    }))
+
+    Alpine.start()
+
+    await waitFor(() => {
+        expect(document.querySelector('p').textContent).toEqual('loaded')
+    })
+
+    document.querySelector('button').click()
+
+    // Again, jest doesn't have a viewport so we can only check that the native
+    // function is called correctly
+    expect(window.scroll).toHaveBeenCalledWith({ behavior: 'smooth', top: 120 })
+})


### PR DESCRIPTION
Fixes #52 
getBoundingClientRect can return decimal numbers (e.g. rem values) and $scroll was not supporting it in that case.
We round down to the previous pixel in that case.