### PR TITLE
Add clarity about the usage of $parent and $component in x-init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - [`$component`]: $component and $parent are now deferred for a few ms if the observed component is not ready
+- [`$component`]: **BREAKING** `$component...` and `$parent...` in `x-init` are now always resolving to empty strings.
 
 ## [0.6.0] - 2021-02-05
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Magic Helpers
 
 A collection of magic properties and helper functions for use with [Alpine.js](https://github.com/alpinejs/alpine)
@@ -21,6 +22,9 @@ Adds the following magic helpers to use with Alpine JS. ***More to come!***
 | [`$undo`](#undo) |  Track and undo state changes inside your component. |
 
 🚀 If you have ideas for more magic helpers, please open a [discussion](https://github.com/alpine-collective/alpine-magic-helpers/discussions) or join us on the [AlpineJS Discord](https://discord.gg/snmCYk3)
+
+**Known issues**
+* [Using `$component`/`$parent` in `x-init`](#warning-using-componentparent-in-x-init)
 
 ## Installation
 
@@ -94,6 +98,33 @@ You may watch other components, but you must give them each an id using the 'id'
 <div x-id="yellowSquare" x-data="{ color: 'yellow' }"></div>
 ```
 
+#### :warning: **Using `$component`/`$parent` in `x-init`**
+```html
+ <!-- This won't populate baz correctly -->
+ <div x-data="{ foo: 'bar' }">
+   <div x-data="{ baz: null }" x-init="() => baz = $parent.foo">
+     <span x-text='baz'></span>
+   </div>
+ </div>
+ <!-- use this instead -->
+ <div x-data="{ foo: 'bar' }">
+   <div x-data="{ baz: null }" x-init="$nextTick(() => baz = $parent.foo)">
+     <span x-text='childMsg'></span>
+   </div>
+ </div>
+ <!-- or -->
+ <div x-data="{ foo: 'bar' }">
+   <div x-data="{ baz: null }" x-init="setTimeout(() => baz = $parent.foo)">
+     <span x-text='childMsg'></span>
+   </div>
+ </div>
+```
+When a component initialize, the observed component may not be ready yet due to the why Alpine starts up. This is always true for `$parent` and it occurs for `$component` where the observer is placed before the observed component in the page structure. 
+Previous versions were using a hack to evaluate the missing x-data on the fly but that strategy wasn't allowing to use nested magic properties and it was not syncronising properly in some edge cases. 
+The magic helper since version 1.0 defers the resolution of those properties (resolving temporary to empty strings/noop functions) until the observed component is ready and then refreshes the component: this happens in a few milliseconds and it's not noticable by the final users but refreshing a component won't rerun `x-init` with the correct values.
+**If developers need to use the magic property inside x-init, they'll need to manually postpone the execution of x-init for one tick either using the Alpine native $nextTick or a setTimeout with no duration (See examples above).**
+
+---
 
 ### `$fetch`
 **Example:**

--- a/README.md
+++ b/README.md
@@ -108,13 +108,13 @@ You may watch other components, but you must give them each an id using the 'id'
  <!-- use this instead -->
  <div x-data="{ foo: 'bar' }">
    <div x-data="{ baz: null }" x-init="$nextTick(() => baz = $parent.foo)">
-     <span x-text='childMsg'></span>
+     <span x-text='baz'></span>
    </div>
  </div>
  <!-- or -->
  <div x-data="{ foo: 'bar' }">
    <div x-data="{ baz: null }" x-init="setTimeout(() => baz = $parent.foo)">
-     <span x-text='childMsg'></span>
+     <span x-text='baz'></span>
    </div>
  </div>
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Magic Helpers
 
 A collection of magic properties and helper functions for use with [Alpine.js](https://github.com/alpinejs/alpine)
@@ -119,10 +118,10 @@ You may watch other components, but you must give them each an id using the 'id'
    </div>
  </div>
 ```
-When a component initialize, the observed component may not be ready yet due to the why Alpine starts up. This is always true for `$parent` and it occurs for `$component` where the observer is placed before the observed component in the page structure. 
+When a component is initialised, the observed component may not be ready yet due to the way Alpine starts up. This is always true for `$parent` and it occurs for `$component` when the observer is placed before the observed component in the page structure. 
 Previous versions were using a hack to evaluate the missing x-data on the fly but that strategy wasn't allowing to use nested magic properties and it was not syncronising properly in some edge cases. 
 The magic helper since version 1.0 defers the resolution of those properties (resolving temporary to empty strings/noop functions) until the observed component is ready and then refreshes the component: this happens in a few milliseconds and it's not noticable by the final users but refreshing a component won't rerun `x-init` with the correct values.
-**If developers need to use the magic property inside x-init, they'll need to manually postpone the execution of x-init for one tick either using the Alpine native $nextTick or a setTimeout with no duration (See examples above).**
+**If developers need to use the magic property inside x-init, they'll need to manually postpone the execution of x-init for one tick either using the Alpine native `$nextTick` or a setTimeout with no duration (See examples above).**
 
 ---
 


### PR DESCRIPTION
Currently, accessing `$parent` and `$component` subproperties in `x-init` always returns empty strings and noop functions because the observed component is not ready yet. 
Note it was working in 0.x because we were evaluating the missing x-data on the fly but the resulted object was lacking some alpine functionalities such as custom magic properties, $el, $refs, etc.
It's probably good to warn the user about this BC and provide a reasonable workaround so I added a specific section in the readme.

We don't need a release for this PR.

Closes #95 