### PR TITLE
Typo in auto changelog update

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -58,7 +58,7 @@ jobs:
         run: git commit -am 'Update version in README'
         continue-on-error: true
       - name: Update CHANGELOG
-        run: sed -i "/\[Unreleased\]/a\\\n## [${CDN_VERSION}] - $(date +"%Y-%m-%d")" CHANGELOG.md
+        run: sed -i "/\[Unreleased\]/a\\\n## [${RELEASE_VERSION}] - $(date +"%Y-%m-%d")" CHANGELOG.md
       - name: Commit CHANGELOG
         run: git commit -am 'Update version in README'
       - name: Push changed files to master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.2.x] - 2021-04-18
+## [1.2.0] - 2021-04-18
 ### Added
 - [`$get`/`$post`]: Added two helpers to simplify working with `$fetch`
-## [1.1.x] - 2021-03-15
+
+## [1.1.0] - 2021-03-15
 ### Added
 - [`x-unsafe-html`]: Added 'x-unsafe-html' custom directive
 


### PR DESCRIPTION
The current script was using the CDN version in the changelog which doesn't have the patch number. 